### PR TITLE
Fix no humidity magic value to 0

### DIFF
--- a/custom_components/air_cloud/climate.py
+++ b/custom_components/air_cloud/climate.py
@@ -32,6 +32,7 @@ SUPPORT_HVAC = [
     HVACMode.AUTO,
     HVACMode.HEAT
 ]
+NO_HUMIDITY_VALUE = 2147483647
 
 
 async def _async_setup(hass, async_add):
@@ -313,5 +314,7 @@ class AirCloudClimateEntity(ClimateEntity):
         self._fan_swing = climate_data["fanSwing"]
 
         self._humidity = climate_data.get("humidity", 0)
-        if self._humidity < 2147483647:
+        if self._humidity < NO_HUMIDITY_VALUE:
             self._humidity = 50
+        elif self._humidity == NO_HUMIDITY_VALUE:
+            self._humidity = 0


### PR DESCRIPTION
After the 2.0.7 update, I couldn't do anything on my climate.
After some digging and test on my HA instance, I ended up with the code here,
which basiclayy reset the self._humidity value to 0 when we get the "magic" `2147483647` value of humidity,
like it was the case before.

I hope I didn't break what was doing the 2.0.7 fix.

