### PR TITLE
Use relative temperature in auto mode

### DIFF
--- a/custom_components/air_cloud/api.py
+++ b/custom_components/air_cloud/api.py
@@ -140,16 +140,26 @@ class AirCloudApi:
         struct = json.loads(message)
         return struct["data"]
 
-    async def execute_command(self, id, family_id, power, idu_temperature, mode, fan_speed, fan_swing, humidity):
+    async def execute_command(self, id, family_id, power, temperature, mode, fan_speed, fan_swing, humidity):
         await self.__refresh_token()
-        command = {
+        if mode == "AUTO":
+            command = {
             "power": power,
-            "iduTemperature": idu_temperature,
+            "relativeTemperature": temperature,
             "mode": mode,
             "fanSpeed": fan_speed,
             "fanSwing": fan_swing,
             "humidity": humidity
-        }
+            }
+        else:
+            command = {
+            "power": power,
+            "iduTemperature": temperature,
+            "mode": mode,
+            "fanSpeed": fan_speed,
+            "fanSwing": fan_swing,
+            "humidity": humidity
+            }
         async with self._session.put(
             f"{HOST_API}{URN_CONTROL}/{id}?familyId={family_id}",
             headers=self.__create_headers(),

--- a/custom_components/air_cloud/climate.py
+++ b/custom_components/air_cloud/climate.py
@@ -294,6 +294,9 @@ class AirCloudClimateEntity(ClimateEntity):
 
         if self._mode == "FAN":
             target_temp = 0
+        elif self._mode == "AUTO":
+            # Clamp the value between -3 and +3 after subtracting 25
+            target_temp = max(-3, min(3, target_temp - 25))
 
         await self._api.execute_command(self._id, self._family_id, self._power, target_temp, self._mode,
                                         self._fan_speed, self._fan_swing, self._humidity)
@@ -304,7 +307,10 @@ class AirCloudClimateEntity(ClimateEntity):
     def __update_data(self, climate_data):
         self._power = climate_data["power"]
         self._mode = climate_data["mode"]
-        self._target_temp = climate_data["iduTemperature"]
+        if climate_data["mode"] == "AUTO":
+            self._target_temp = climate_data["iduTemperature"] + 25
+        else:
+            self._target_temp = climate_data["iduTemperature"]
 
         self._room_temp = climate_data.get("roomTemperature")
         if self._room_temp is not None and self._temp_adjust is not None:


### PR DESCRIPTION
My heat pump when in auto mode is using the relative temperature instead of the idu temperature, to read and set the temperature. I think this fixes #10, but I'm not sure if this is model dependent or valid for all heat pumps in Airloud Go 