### PR TITLE
Change temperature step to 1

### DIFF
--- a/custom_components/air_cloud/climate.py
+++ b/custom_components/air_cloud/climate.py
@@ -110,7 +110,7 @@ class AirCloudClimateEntity(ClimateEntity):
 
     @property
     def target_temperature_step(self):
-        return 0.5
+        return 1
 
     @property
     def max_temp(self):


### PR DESCRIPTION
My heat pump only supports increments of whole degrees. I'm not sure if this is model dependent or valid for all heat pumps accessible through airCloud Go.