### PR TITLE
Fix Home Assistant compatibility and command payload handling

### DIFF
--- a/custom_components/air_cloud/api.py
+++ b/custom_components/air_cloud/api.py
@@ -6,7 +6,17 @@ import uuid
 from datetime import datetime
 from aiohttp import WSMsgType
 
-from .const import HOST_API, URN_AUTH, URN_WHO, URN_WSS, URN_CONTROL, URN_REFRESH_TOKEN, URN_ENERGY_CONSUMPTION_SUMMARY, URN_RAC_CONFIGURATION, USER_AGENT
+from .const import (
+    HOST_API,
+    URN_AUTH,
+    URN_CONTROL,
+    URN_ENERGY_CONSUMPTION_SUMMARY,
+    URN_RAC_CONFIGURATION,
+    URN_REFRESH_TOKEN,
+    URN_WHO,
+    URN_WSS,
+    USER_AGENT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,13 +37,26 @@ class AirCloudApi:
             await self.__authenticate()
             return True
         except Exception as e:
-            logging.error("Failed to validate credentials: %s", str(e))
+            _LOGGER.error("Failed to validate credentials: %s", str(e))
             return False
 
     async def __authenticate(self):
         authorization = {"email": self._login, "password": self._password}
-        async with self._session.post(HOST_API + URN_AUTH, json=authorization, headers={"User-Agent": USER_AGENT}) as response:
-            await self.__update_token_data(await response.json())
+
+        async with self._session.post(
+            HOST_API + URN_AUTH,
+            json=authorization,
+            headers={"User-Agent": USER_AGENT},
+        ) as response:
+            response_text = await response.text()
+            _LOGGER.debug(
+                "air_cloud.api: auth status=%s body=%s",
+                response.status,
+                response_text[:500],
+            )
+            response.raise_for_status()
+            await self.__update_token_data(json.loads(response_text))
+
         self._last_token_update = datetime.now()
 
     async def __refresh_token(self, forced=False):
@@ -46,11 +69,20 @@ class AirCloudApi:
         elif td_minutes[1] > 5:
             async with self._session.post(
                 HOST_API + URN_REFRESH_TOKEN,
-                headers={"Authorization": f"Bearer {self._ref_token}",
-                         "isRefreshToken": "true",
-                         "User-Agent": USER_AGENT}
+                headers={
+                    "Authorization": f"Bearer {self._ref_token}",
+                    "isRefreshToken": "true",
+                    "User-Agent": USER_AGENT,
+                },
             ) as response:
-                await self.__update_token_data(await response.json())
+                response_text = await response.text()
+                _LOGGER.debug(
+                    "air_cloud.api: refresh status=%s body=%s",
+                    response.status,
+                    response_text[:500],
+                )
+                response.raise_for_status()
+                await self.__update_token_data(json.loads(response_text))
             self._last_token_update = now_datetime
 
     async def __update_token_data(self, response):
@@ -61,37 +93,62 @@ class AirCloudApi:
         await self.__refresh_token()
         async with self._session.get(
             HOST_API + URN_WHO,
-            headers=self.__create_headers()
+            headers=self.__create_headers(),
         ) as response:
-            response_data = await response.json()
-            family_ids = [item["familyId"] for item in response_data]
-            return family_ids
+            response_text = await response.text()
+            _LOGGER.debug(
+                "air_cloud.api: who status=%s body=%s",
+                response.status,
+                response_text[:1000],
+            )
+            response.raise_for_status()
+            response_data = json.loads(response_text)
+            return [item["familyId"] for item in response_data]
 
     async def load_energy_consumption_summary(self, family_id):
         await self.__refresh_token()
         async with self._session.post(
             f"{HOST_API}{URN_ENERGY_CONSUMPTION_SUMMARY}?familyId={family_id}",
             headers=self.__create_headers(),
-            json={"from": "2000-01-01", "to": "2099-12-31"}
+            json={"from": "2000-01-01", "to": "2099-12-31"},
         ) as response:
-            return await response.json()
+            response_text = await response.text()
+            _LOGGER.debug(
+                "air_cloud.api: energy status=%s family_id=%s body=%s",
+                response.status,
+                family_id,
+                response_text[:1000],
+            )
+            response.raise_for_status()
+            return json.loads(response_text)
 
     async def load_rac_configuration(self, cloud_ids):
         await self.__refresh_token()
         async with self._session.post(
             HOST_API + URN_RAC_CONFIGURATION,
             headers=self.__create_headers(),
-            json=cloud_ids
+            json=cloud_ids,
         ) as response:
-            return await response.json()
+            response_text = await response.text()
+            _LOGGER.debug(
+                "air_cloud.api: rac config status=%s cloud_ids=%s body=%s",
+                response.status,
+                cloud_ids,
+                response_text[:1000],
+            )
+            response.raise_for_status()
+            return json.loads(response_text)
 
     async def load_climate_data(self, family_id):
         if self._session.closed:
+            _LOGGER.debug("air_cloud.api: sessão fechada em load_climate_data")
             return []
+
         await self.__refresh_token()
 
-        # Открываем новое соединение
-        async with self._session.ws_connect(URN_WSS, timeout=60, headers={"User-Agent": USER_AGENT}) as ws:
+        async with self._session.ws_connect(
+            URN_WSS, timeout=60, headers={"User-Agent": USER_AGENT}
+        ) as ws:
             connection_string = (
                 "CONNECT\naccept-version:1.1,1.2\nheart-beat:10000,10000\n"
                 "Authorization:Bearer {}\n\n\0\n"
@@ -100,8 +157,9 @@ class AirCloudApi:
                 self._token,
                 str(uuid.uuid4()),
                 str(family_id),
-                str(family_id)
+                str(family_id),
             )
+
             await ws.send_str(connection_string)
 
             try:
@@ -114,13 +172,15 @@ class AirCloudApi:
                     msg = await asyncio.wait_for(ws.receive(), timeout=10)
 
                     if msg.type == WSMsgType.TEXT:
-
                         if msg.data.startswith("CONNECTED") and "user-name:" not in msg.data:
-                            _LOGGER.warning("Websocket connection failed. Re-authenticating.")
                             await ws.close()
 
                             await self.__refresh_token(forced=True)
-                            ws = await self._session.ws_connect(URN_WSS, timeout=60, headers={"User-Agent": USER_AGENT})
+                            ws = await self._session.ws_connect(
+                                URN_WSS,
+                                timeout=60,
+                                headers={"User-Agent": USER_AGENT},
+                            )
                             connection_string = (
                                 "CONNECT\naccept-version:1.1,1.2\nheart-beat:10000,10000\n"
                                 "Authorization:Bearer {}\n\n\0\n"
@@ -129,7 +189,7 @@ class AirCloudApi:
                                 self._token,
                                 str(uuid.uuid4()),
                                 str(family_id),
-                                str(family_id)
+                                str(family_id),
                             )
                             await ws.send_str(connection_string)
                             attempt = 0
@@ -140,20 +200,17 @@ class AirCloudApi:
                             break
 
                     elif msg.type == WSMsgType.CLOSED:
-                        _LOGGER.warning("WebSocket connection is closed.")
                         return None
+
                 else:
-                    _LOGGER.warning("Unable to find '{' symbol after %d attempts", max_attempts)
                     await ws.close()
                     return None
 
             except asyncio.TimeoutError:
-                _LOGGER.warning("WebSocket connection timed out while receiving data")
                 await ws.close()
                 return None
 
         if not response:
-            _LOGGER.warning("No valid response received from WebSocket.")
             return None
 
         _LOGGER.debug("AirCloud climate data: %s", response)
@@ -163,36 +220,50 @@ class AirCloudApi:
 
     async def execute_command(self, id, family_id, power, temperature, mode, fan_speed, fan_swing, humidity):
         if self._session.closed:
+            _LOGGER.debug("air_cloud.api: sessão fechada em execute_command")
             return
+
         await self.__refresh_token()
+
         if mode == "AUTO":
             command = {
-            "power": power,
-            "relativeTemperature": temperature,
-            "mode": mode,
-            "fanSpeed": fan_speed,
-            "fanSwing": fan_swing,
-            "humidity": humidity
+                "power": power,
+                "relativeTemperature": temperature,
+                "mode": mode,
+                "fanSpeed": fan_speed,
+                "fanSwing": fan_swing,
             }
         else:
             command = {
-            "power": power,
-            "iduTemperature": temperature,
-            "mode": mode,
-            "fanSpeed": fan_speed,
-            "fanSwing": fan_swing,
-            "humidity": humidity
+                "power": power,
+                "iduTemperature": temperature,
+                "mode": mode,
+                "fanSpeed": fan_speed,
+                "fanSwing": fan_swing,
             }
+
+        url = f"{HOST_API}{URN_CONTROL}/{id}?familyId={family_id}"
+
+        _LOGGER.debug("air_cloud.api: PUT %s payload=%s", url, command)
+
         async with self._session.put(
-            f"{HOST_API}{URN_CONTROL}/{id}?familyId={family_id}",
+            url,
             headers=self.__create_headers(),
-            json=command
+            json=command,
         ) as response:
-            _LOGGER.debug("AirCloud command request: %s", command)
-            _LOGGER.debug("AirCloud command response: %s", await response.text())
+            response_text = await response.text()
+            _LOGGER.debug(
+                "air_cloud.api: command status=%s body=%s",
+                response.status,
+                response_text[:1000],
+            )
+            response.raise_for_status()
 
     def __create_headers(self):
-        return {"Authorization": f"Bearer {self._token}", "User-Agent": USER_AGENT}
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "User-Agent": USER_AGENT,
+        }
 
     async def close_session(self):
         await self._session.close()

--- a/custom_components/air_cloud/climate.py
+++ b/custom_components/air_cloud/climate.py
@@ -1,27 +1,34 @@
 import asyncio
-from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate.const import (FAN_AUTO, SWING_OFF,
-                                                    SWING_VERTICAL,
-                                                    SWING_HORIZONTAL,
-                                                    SWING_BOTH)
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
-from homeassistant.components.climate.const import HVACMode, ClimateEntityFeature
+import logging
 
-from .const import DOMAIN, API, CONF_TEMP_ADJUST, CONF_TEMP_STEP
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
+    FAN_AUTO,
+    SWING_BOTH,
+    SWING_HORIZONTAL,
+    SWING_OFF,
+    SWING_VERTICAL,
+)
+from homeassistant.components.climate.const import HVACMode, ClimateEntityFeature
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+
+from .const import API, CONF_TEMP_ADJUST, CONF_TEMP_STEP, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 NO_HUMIDITY_VALUE = 2147483647
 
 
 async def _async_setup(hass, async_add):
     api = hass.data[DOMAIN][API]
-    
+
     family_ids = await api.load_family_ids()
-    
+
     cloud_ids = []
     all_devices = []
 
     for family_id in family_ids:
-        family_devices = await api.load_climate_data(family_id)
+        family_devices = await api.load_climate_data(family_id) or []
         for device in family_devices:
             cloud_ids.append(device["cloudId"])
             all_devices.append((device, family_id))
@@ -34,8 +41,10 @@ async def _async_setup(hass, async_add):
     entities = []
     for device, family_id in all_devices:
         rac_config = rac_config_map.get(device["cloudId"])
-        entities.append(AirCloudClimateEntity(api, device, hass, family_id, rac_config))
-        
+        entities.append(
+            AirCloudClimateEntity(api, device, hass, family_id, rac_config)
+        )
+
     if entities:
         async_add(entities, update_before_add=False)
 
@@ -53,18 +62,19 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
     all_devices = []
 
     for family_id in family_ids:
-        family_devices = await api.load_climate_data(family_id)
+        family_devices = await api.load_climate_data(family_id) or []
         for device in family_devices:
             cloud_ids.append(device["cloudId"])
             all_devices.append((device, family_id))
 
+    rac_config_map = {}
     if cloud_ids:
         rac_configs = await api.load_rac_configuration(cloud_ids)
         rac_config_map = {config["cloudId"]: config for config in rac_configs}
 
-        for device, family_id in all_devices:
-            rac_config = rac_config_map.get(device["cloudId"])
-            entities.append(AirCloudClimateEntity(api, device, hass, family_id, rac_config))
+    for device, family_id in all_devices:
+        rac_config = rac_config_map.get(device["cloudId"])
+        entities.append(AirCloudClimateEntity(api, device, hass, family_id, rac_config))
 
     if entities:
         async_add_devices(entities)
@@ -96,7 +106,6 @@ class AirCloudClimateEntity(ClimateEntity):
         if not rac_config:
             return
 
-        # HVAC Modes
         for mode_data in rac_config.get("racOperationModes", []):
             mode = mode_data.get("mode")
             reference = mode_data.get("referenceTemperature", 0.0)
@@ -104,8 +113,9 @@ class AirCloudClimateEntity(ClimateEntity):
             max_temp = mode_data.get("maxTemperature", 32.0)
             self._temp_limits[mode] = {
                 "min": min_temp + reference,
-                "max": max_temp + reference
+                "max": max_temp + reference,
             }
+
             if mode == "COOLING":
                 self._attr_hvac_modes.append(HVACMode.COOL)
             elif mode == "HEATING":
@@ -117,7 +127,6 @@ class AirCloudClimateEntity(ClimateEntity):
             elif mode == "AUTO":
                 self._attr_hvac_modes.append(HVACMode.AUTO)
 
-        # Swing Modes
         swing_config = rac_config.get("swing", {})
         vertical = swing_config.get("VERTICAL", False)
         horizontal = swing_config.get("HORIZONTAL", False)
@@ -129,7 +138,6 @@ class AirCloudClimateEntity(ClimateEntity):
         if vertical and horizontal:
             self._attr_swing_modes.append(SWING_BOTH)
 
-        # Fan Modes
         available_speeds = set()
         for mode_data in rac_config.get("racOperationModes", []):
             enable_fan = mode_data.get("enableFanSpeed", {})
@@ -163,12 +171,20 @@ class AirCloudClimateEntity(ClimateEntity):
 
     @property
     def extra_state_attributes(self):
-        return {"family_id": self._family_id, "air_cloud_id": self._id, "cloud_id": self._cloud_id}
+        return {
+            "family_id": self._family_id,
+            "air_cloud_id": self._id,
+            "cloud_id": self._cloud_id,
+        }
 
     @property
     def supported_features(self):
-        support_flags = (ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
-                         | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF)
+        support_flags = (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.TURN_ON
+            | ClimateEntityFeature.TURN_OFF
+        )
 
         if len(self._attr_swing_modes) > 1:
             support_flags |= ClimateEntityFeature.SWING_MODE
@@ -189,7 +205,7 @@ class AirCloudClimateEntity(ClimateEntity):
 
     @property
     def target_temperature_step(self):
-        step_data = self._hass.data[DOMAIN].get(CONF_TEMP_STEP, {})
+        step_data = self._hass.data.get(DOMAIN, {}).get(CONF_TEMP_STEP, {})
         step = step_data.get(self._id)
         if step is None:
             return 0.5
@@ -221,8 +237,7 @@ class AirCloudClimateEntity(ClimateEntity):
             return HVACMode.DRY
         elif self._mode == "AUTO":
             return HVACMode.AUTO
-        else:
-            return HVACMode.OFF
+        return HVACMode.OFF
 
     @property
     def hvac_modes(self):
@@ -242,8 +257,7 @@ class AirCloudClimateEntity(ClimateEntity):
             return "High"
         elif self._fan_speed == "LV5":
             return "Turbo"
-        else:
-            return FAN_AUTO
+        return FAN_AUTO
 
     @property
     def fan_modes(self):
@@ -257,42 +271,19 @@ class AirCloudClimateEntity(ClimateEntity):
             return SWING_HORIZONTAL
         elif self._fan_swing == "BOTH":
             return SWING_BOTH
-        else:
-            return SWING_OFF
+        return SWING_OFF
 
     @property
     def swing_modes(self):
         return self._attr_swing_modes
 
-    def turn_on(self):
-        asyncio.run(self.async_turn_on())
-
-    def turn_off(self):
-        asyncio.run(self.async_turn_off())
-
-    def set_hvac_mode(self, hvac_mode):
-        asyncio.run(self.async_set_hvac_mode(hvac_mode))
-
-    def set_preset_mode(self, preset_mode):
-        asyncio.run(self.async_set_preset_mode(preset_mode))
-
-    def set_fan_mode(self, fan_mode):
-        asyncio.run(self.async_set_fan_mode(fan_mode))
-
-    def set_swing_mode(self, swing_mode):
-        asyncio.run(self.async_set_swing_mode(swing_mode))
-
-    def set_temperature(self, **kwargs):
-        asyncio.run(self.async_set_temperature(**kwargs))
-
-    def update(self):
-        asyncio.run(self.async_update())
-
     async def async_turn_on(self):
+        self._update_lock = True
         self._power = "ON"
         await self.__execute_command()
 
     async def async_turn_off(self):
+        self._update_lock = True
         self._power = "OFF"
         await self.__execute_command()
 
@@ -317,9 +308,6 @@ class AirCloudClimateEntity(ClimateEntity):
         else:
             self._power = "OFF"
 
-        await self.__execute_command()
-
-    async def async_set_preset_mode(self, preset_mode):
         await self.__execute_command()
 
     async def async_set_fan_mode(self, fan_mode):
@@ -361,6 +349,7 @@ class AirCloudClimateEntity(ClimateEntity):
 
         target_temp = kwargs.get(ATTR_TEMPERATURE)
         if target_temp is None:
+            self._update_lock = False
             return
 
         self._target_temp = target_temp
@@ -369,12 +358,22 @@ class AirCloudClimateEntity(ClimateEntity):
     async def async_update(self):
         if self._update_lock is False:
             try:
-                devices = await asyncio.wait_for(self._api.load_climate_data(self._family_id), timeout=10)
-                for device in devices:
+                devices = await asyncio.wait_for(
+                    self._api.load_climate_data(self._family_id), timeout=10
+                )
+                for device in devices or []:
                     if self._id == device["id"]:
                         self.__update_data(device)
+                        _LOGGER.debug(
+                            "air_cloud: estado atualizado para %s | power=%s mode=%s target=%s room=%s",
+                            self._name,
+                            self._power,
+                            self._mode,
+                            self._target_temp,
+                            self._room_temp,
+                        )
             except asyncio.TimeoutError:
-                pass
+                _LOGGER.debug("air_cloud: timeout ao atualizar %s", self._name)
 
     async def __execute_command(self):
         target_temp = self._target_temp
@@ -382,11 +381,29 @@ class AirCloudClimateEntity(ClimateEntity):
         if self._mode == "FAN":
             target_temp = 0
         elif self._mode == "AUTO":
-            # Clamp the value between -3 and +3 after subtracting 25
             target_temp = max(-3, min(3, target_temp - 25))
 
-        await self._api.execute_command(self._id, self._family_id, self._power, target_temp, self._mode,
-                                        self._fan_speed, self._fan_swing, self._humidity)
+        _LOGGER.debug(
+            "air_cloud: comando %s | power=%s temp=%s mode=%s fan=%s swing=%s",
+            self._name,
+            self._power,
+            target_temp,
+            self._mode,
+            self._fan_speed,
+            self._fan_swing,
+        )
+
+        await self._api.execute_command(
+            self._id,
+            self._family_id,
+            self._power,
+            target_temp,
+            self._mode,
+            self._fan_speed,
+            self._fan_swing,
+            self._humidity,
+        )
+
         await asyncio.sleep(10)
         self._update_lock = False
         await self.async_update()
@@ -394,20 +411,18 @@ class AirCloudClimateEntity(ClimateEntity):
     def __update_data(self, climate_data):
         self._power = climate_data["power"]
         self._mode = climate_data["mode"]
+
         if climate_data["mode"] == "AUTO" and self._power == "ON":
             self._target_temp = climate_data["iduTemperature"] + 25
         else:
             self._target_temp = climate_data["iduTemperature"]
 
-        # Get adjustment from shared data
-        adjust_data = self._hass.data[DOMAIN].get(CONF_TEMP_ADJUST, {})
+        adjust_data = self._hass.data.get(DOMAIN, {}).get(CONF_TEMP_ADJUST, {})
         temp_adjust = adjust_data.get(self._id)
-
         if temp_adjust is None:
             temp_adjust = 0.0
 
         self._room_temp = climate_data.get("roomTemperature")
-
         if self._room_temp is not None:
             self._room_temp = self._room_temp + temp_adjust
 


### PR DESCRIPTION
This PR fixes a few issues I found while testing the integration on my setup.

Tested on Hitachi RPK12C5IVQ units with a recent Home Assistant version.

Changes:
- avoid KeyError when hass.data["air_cloud"] is missing
- remove humidity from command payload to prevent 400 Bad Request
- remove synchronous asyncio.run wrappers from climate entity methods
- keep command execution and state updates working correctly

Symptoms before this fix:
- climate service calls could fail with KeyError: 'air_cloud'
- command requests returned 400 Bad Request for my units
- entities were readable, but device control was failing

After this fix:
- turn on/off works
- hvac mode changes work
- temperature changes work
- state updates continue to work correctly